### PR TITLE
chore: stop using macos CI runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: true
       max-parallel: 1
     name: Test leaderboard examples on node ${{ matrix.node }}
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     steps:
       - name: Setup repo


### PR DESCRIPTION
In the past, we had issues with ubuntu runners in certain situations and were forced to use macos, which is much more expensive. Those issues have now been resolved on the Azure/github side, so we can switch back to ubuntu to reduce costs.
